### PR TITLE
Ensure the computation stays in single precision

### DIFF
--- a/gpt2.py
+++ b/gpt2.py
@@ -46,7 +46,7 @@ def mha(x, c_attn, c_proj, n_head):  # [n_seq, n_embd] -> [n_seq, n_embd]
     qkv_heads = list(map(lambda x: np.split(x, n_head, axis=-1), qkv))  # [3, n_seq, n_embd] -> [3, n_head, n_seq, n_embd/n_head]
 
     # causal mask to hide future inputs from being attended to
-    causal_mask = (1 - np.tri(x.shape[0])) * -1e10  # [n_seq, n_seq]
+    causal_mask = (1 - np.tri(x.shape[0], dtype=np.float32)) * -1e10  # [n_seq, n_seq]
 
     # perform attention over each head
     out_heads = [attention(q, k, v, causal_mask) for q, k, v in zip(*qkv_heads)]  # [3, n_head, n_seq, n_embd/n_head] -> [n_head, n_seq, n_embd/n_head]

--- a/gpt2_pico.py
+++ b/gpt2_pico.py
@@ -24,7 +24,7 @@ def attention(q, k, v, mask):
 def mha(x, c_attn, c_proj, n_head):
     x = linear(x, **c_attn)
     qkv_heads = list(map(lambda x: np.split(x, n_head, axis=-1), np.split(x, 3, axis=-1)))
-    causal_mask = (1 - np.tri(x.shape[0])) * -1e10
+    causal_mask = (1 - np.tri(x.shape[0], dtype=np.float32)) * -1e10
     out_heads = [attention(q, k, v, causal_mask) for q, k, v in zip(*qkv_heads)]
     x = linear(np.hstack(out_heads), **c_proj)
     return x


### PR DESCRIPTION
On my computer this change makes picoGPT several times faster.

Before:
```console
$ time python gpt2.py 'Alan Turing theorized that computers would one day become' --models_dir ../gpt2/models 
generating: 100%|███████████████████████████████| 40/40 [00:16<00:00,  2.40it/s]
 the most powerful machines on the planet.

The computer is a machine that can perform complex calculations, and it can perform these calculations in a way that is very similar to the human brain.

python gpt2.py 'Alan Turing theorized that computers would one day become'    95.80s user 1.85s system 516% cpu 18.913 total
```
After:
```console
$ time python gpt2.py 'Alan Turing theorized that computers would one day become' --models_dir ../gpt2/models
generating: 100%|███████████████████████████████| 40/40 [00:03<00:00, 12.11it/s]
 the most powerful machines on the planet.

The computer is a machine that can perform complex calculations, and it can perform these calculations in a way that is very similar to the human brain.

python gpt2.py 'Alan Turing theorized that computers would one day become'    22.94s user 0.72s system 428% cpu 5.526 total
```

The inference went from 16s to 3s.