### PR TITLE
add full support for JAX in utils.py

### DIFF
--- a/gpt2.py
+++ b/gpt2.py
@@ -72,7 +72,7 @@ def transformer_block(x, mlp, attn, ln_1, ln_2, n_head):  # [n_seq, n_embd] -> [
 
 def gpt2(inputs, wte, wpe, blocks, ln_f, n_head):  # [n_seq] -> [n_seq, n_vocab]
     # token + positional embeddings
-    x = wte[inputs] + wpe[range(len(inputs))]  # [n_seq] -> [n_seq, n_embd]
+    x = wte[np.array(inputs)] + wpe[np.array(range(len(inputs)))]  # [n_seq] -> [n_seq, n_embd]
 
     # forward pass through n_layer transformer blocks
     for block in blocks:

--- a/gpt2_pico.py
+++ b/gpt2_pico.py
@@ -35,7 +35,7 @@ def transformer_block(x, mlp, attn, ln_1, ln_2, n_head):
     return x
 
 def gpt2(inputs, wte, wpe, blocks, ln_f, n_head):
-    x = wte[inputs] + wpe[range(len(inputs))]
+    x = wte[np.array(inputs)] + wpe[np.array(range(len(inputs)))] 
     for block in blocks:
         x = transformer_block(x, **block, n_head=n_head)
     return layer_norm(x, **ln_f) @ wte.T


### PR DESCRIPTION
Hi Jay, thank you for making the PicoGPT repo. It is very useful, as well as the blog I was following it to understand the GPT model more. 

The current version of the repo does support the JAX numpy API. However, for full support, you may consider these changes. I found out that if I also change utils.py numpy to jax.numpy an issue arises ([Issue 4564](https://github.com/google/jax/issues/4564)). 

So if you modified both gpt2.py and utlis.py to use jax.numpy on the new changes, it should work fine. Also for the current version work fine. 

in gpt2 function
**token + positional embeddings**
```
    x = wte[np.array(inputs)] + wpe[np.array(range(len(inputs)))]  # [n_seq] -> [n_seq, n_embd]
```