### PR TITLE
Adds speculative decoding

### DIFF
--- a/benchmark_speculative.py
+++ b/benchmark_speculative.py
@@ -1,0 +1,50 @@
+import time
+from gpt2 import main as gpt2_main
+from utils import load_encoder_hparams_and_params
+
+def benchmark_generation(prompt, n_tokens_to_generate, model_size, use_speculative):
+    start_time = time.time()
+    gpt2_main(prompt, n_tokens_to_generate, model_size, use_generate_speculative=use_speculative)
+    end_time = time.time()
+    return end_time - start_time
+
+def run_benchmark(prompt, n_tokens_to_generate, model_sizes):
+    results = {}
+
+    for model_size in model_sizes:
+        print(f"Benchmarking {model_size} model...")
+        
+        # Warm-up run
+        benchmark_generation(prompt, n_tokens_to_generate, model_size, False)
+        benchmark_generation(prompt, n_tokens_to_generate, model_size, True)
+
+        # Actual benchmark
+        standard_time = benchmark_generation(prompt, n_tokens_to_generate, model_size, False)
+        speculative_time = benchmark_generation(prompt, n_tokens_to_generate, model_size, True)
+
+        improvement = (standard_time - speculative_time) / standard_time * 100
+        results[model_size] = {
+            "standard_time": standard_time,
+            "speculative_time": speculative_time,
+            "improvement": improvement
+        }
+
+    return results
+
+def main():
+    prompt = "In a world where artificial intelligence has become ubiquitous"
+    n_tokens_to_generate = 50
+    model_sizes = ["124M", "355M"]
+
+    results = run_benchmark(prompt, n_tokens_to_generate, model_sizes)
+
+    print("\nBenchmark Results:")
+    print("==================")
+    for model_size, data in results.items():
+        print(f"\nModel Size: {model_size}")
+        print(f"Standard Generation Time: {data['standard_time']:.4f} seconds")
+        print(f"Speculative Generation Time: {data['speculative_time']:.4f} seconds")
+        print(f"Improvement: {data['improvement']:.2f}%")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Add Speculative Decoding to picoGPT

This PR implements speculative decoding to improve text generation performance in picoGPT. The implementation uses a smaller draft model (124M) to predict multiple tokens at once, which are then verified by the main model, potentially reducing the number of forward passes needed for generation.

## Key Changes

1. Added `generate_speculative()` function in `gpt2.py` that implements:
   - Draft model token generation (default: 3 tokens at a time)
   - Main model verification of speculative tokens
   - Acceptance/rejection mechanism for speculative predictions

2. Modified `main()` function to support both standard and speculative generation modes
   - Added `use_generate_speculative` flag (defaults to True)
   - Loads both main and draft model parameters
   - Routes to appropriate generation function based on the flag

3. Added `benchmark_speculative.py` for performance comparison:
   - Benchmarks both standard and speculative generation
   - Supports multiple model sizes (124M, 355M)
   - Includes warm-up runs for more accurate measurements
   - Reports generation time and percentage improvement

## Implementation Details

The speculative decoding algorithm works as follows:
1. Draft model (124M) generates N speculative tokens (default N=3)
2. Main model verifies these predictions in a single forward pass
3. Accepted tokens are added to the sequence
4. If rejection occurs, fall back to main model's prediction

## Benefits

- Potential speedup in text generation by reducing the number of forward passes
- Configurable number of speculative tokens
- Minimal memory overhead (reuses existing 124M model as draft model)
- Easy to toggle between standard and speculative modes

## Testing

The PR includes a benchmarking script that measures performance improvements across different model sizes. Results can be reproduced by running:

```bash
python benchmark_speculative.py
```

## Notes

- The draft model is fixed to 124M for simplicity, but this could be made configurable
- The number of speculative tokens (N=3) can be adjusted through the `n_speculative` parameter
- Implementation is kept minimal and numpy-based, consistent with picoGPT's philosophy

## Future Work

- Make draft model size configurable
- Add adaptive speculation length based on acceptance rate
- Optimize verification step for better performance